### PR TITLE
Bugfix for shard-managed report updater

### DIFF
--- a/.github/workflows/BERT-INSTANCE-2.yml
+++ b/.github/workflows/BERT-INSTANCE-2.yml
@@ -3,7 +3,7 @@ name: BERT-INSTANCE-2
 on:
   workflow_dispatch:
   push:
-    branches: [sheetData-refactor]
+    branches: [patching-runner]
   release:
     types: [published]
   schedule:

--- a/.github/workflows/LIVE-RELEASE.yml
+++ b/.github/workflows/LIVE-RELEASE.yml
@@ -1,4 +1,4 @@
-name: BERT-INSTANCE-1
+name: LIVE RELEASE
 # Copy this one into your own repository- change up the things your secrets reference if necessary, and run!
 on:
   workflow_dispatch:

--- a/.github/workflows/LIVE-RELEASE.yml
+++ b/.github/workflows/LIVE-RELEASE.yml
@@ -1,0 +1,32 @@
+name: BERT-INSTANCE-1
+# Copy this one into your own repository- change up the things your secrets reference if necessary, and run!
+on:
+  workflow_dispatch:
+  push:
+
+    branches: [live-release]
+  release:
+    types: [published]
+  schedule:
+    - cron: "0 0 * * SUN"
+
+
+jobs:
+  call-workflow-passing-data:
+    uses: texas-mcallen-mission/deploy-google-app-script-action-typescript/.github/workflows/reusable.yml@v2.2.0
+    with:
+      # Github repository information
+      sha: ${{ github.sha }}
+      event_name: ${{ github.event_name }}
+      actor: ${{ github.actor }}
+      job: ${{ github.job }}
+      repository: ${{ github.repository }}
+      ref_name: ${{ github.ref_name }}
+    secrets:
+      # THESE are the ones that are deployment-specific.
+      IN_CLASPRC_JSON: ${{ secrets.CLASPRC_JSON }}
+      IN_REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+      IN_DEPLOYMENT_ID: ${{ secrets.DEPLOYMENT_ID }}
+      IN_SCRIPT_ID: ${{ secrets.LIVE_RELEASE_SCRIPT_ID }}
+      IN_PARENT_ID: ${{ secrets.LIVE_RELEASE_PARENT_ID }}
+      IN_CONFIG_DATA: ${{ secrets.LIVE_RELEASE_CONFIG_OPTIONS }}

--- a/reports/sharded-updater.ts
+++ b/reports/sharded-updater.ts
@@ -114,7 +114,7 @@ function updateShard(scope: filesystemEntry["fsScope"]) {
     currentState[scope][targetShard.toString()] = true;
     setCacheValues(currentState);
     // LOCKOUT as fast as possible
-    meta_runner(scopeFunctionTargets[scope], triggerTypes.timeBased, targetShard.toString(), true);
+    meta_runner(scopeFunctionTargets[scope], triggerTypes.timeBased, targetShard.toString(), false,targetShard.toString())
     currentState = loadCacheValues();
     currentState[scope][targetShard.toString()] = false;
     setCacheValues(currentState)

--- a/scheduler/scheduler.ts
+++ b/scheduler/scheduler.ts
@@ -2,11 +2,13 @@
 
 
 // This makes using the dLog 
-function meta_runner(functionName, trigger, functionArg1 = undefined, ignoreLockout = false) {
+function meta_runner(functionName, trigger, functionArg1 = undefined, ignoreLockout = false, shardNumber:string|null = null) {
     let logString = "[META_RUNNER] - Running " + functionName.name + " with trigger:" + trigger
+    if(shardNumber != null) {logString += "RUNNING ON SHARD: "+shardNumber}
     if(ignoreLockout){ logString += " EXECUTION LOCKOUT IS DISABLED"}
     console.log(logString);
-    let locker = new meta_locker(functionName.name)
+
+    let locker = new meta_locker(functionName.name,shardNumber)
     if (locker.isLocked()== true && ignoreLockout == false) {
         Logger.log("[META_RUNNER][META_LOCKER] Currently in Lockout, ending execution ")
         return
@@ -32,15 +34,24 @@ function meta_runner(functionName, trigger, functionArg1 = undefined, ignoreLock
 }
 
 
-class meta_locker{
+class meta_locker {
     
-    functionName = ""
-    appendString = "Some Random Words To Avoid Weird Problems"
+    functionName = "";
+    appendString = "Some Random Words To Avoid Weird Problems";
+
+    onShard = false;
+    shardValue: string|null = null 
 
     cacheString = "UNDEFINED"
-    constructor(functionName) {
+    constructor(functionName,shardString:null|string = null) {
         this.functionName = functionName
-        this.cacheString = this.functionName + this.appendString
+        if (shardString != null) {
+            this.onShard = true
+            this.shardValue = shardString
+            this.cacheString = this.functionName + this.appendString + this.shardValue
+        } else {
+            this.cacheString = this.functionName + this.appendString
+        }
     }
 
     isLocked() {


### PR DESCRIPTION
Discovered a bit of a problem with the way ``meta_runner`` implements shard updating- this should in theory fix that particular problem.

Up next: reorganizing how external reports (not the report creator ones) are handled.  (Spoiler: new repository!)