### PR TITLE
Not in data response fixing

### DIFF
--- a/.github/workflows/BERT-INSTANCE-2.yml
+++ b/.github/workflows/BERT-INSTANCE-2.yml
@@ -3,7 +3,7 @@ name: BERT-INSTANCE-2
 on:
   workflow_dispatch:
   push:
-    branches: [102-updates-not-occuring-automatically]
+    branches: [not-in-data-response-fixing]
   release:
     types: [published]
   schedule:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # key-indicator-system
 
-[![CodeFactor](https://www.codefactor.io/repository/github/texas-mcallen-mission/key-indicator-system/badge)](https://www.codefactor.io/repository/github/texas-mcallen-mission/key-indicator-system)
-
 ***This is no longer being actively developed!  It is being maintained, and will continue to be for at least the remainder of 2022.  At this point, it is likely that the only major changes to this system will be stability improvements.***
 
 ## What Is This?

--- a/dataFlow/updateDataSheet.ts
+++ b/dataFlow/updateDataSheet.ts
@@ -68,12 +68,13 @@ function updateDataSheet() {
 function pullFormData(allSheetData) {
     Logger.log("Pulling Form Data...");
 
-    let fSheetData = allSheetData.form;
-    let responses = fSheetData.getData();
-    let missionData = [];
     // Bugfix: the following was previously inside of the last if/else loop.
     let formSheet = fSheetData.getSheet();
     let markerRange = formSheet.getRange("B2:B" + formSheet.getLastRow());
+    
+    let fSheetData = allSheetData.form;
+    let responses = fSheetData.getData();
+    let missionData = [];
 
     Logger.log("[TODO] Limit pullFormData from pulling the whole sheet - sheetData.getRecentData(maxRows) or something similar? Specify max and min rows?");
 

--- a/dataFlow/updateDataSheet.ts
+++ b/dataFlow/updateDataSheet.ts
@@ -71,6 +71,7 @@ function pullFormData(allSheetData) {
     let fSheetData = allSheetData.form;
     let responses = fSheetData.getData();
     let missionData = [];
+    let rangeString = "B2:B" + responses.getLastRow()
 
     Logger.log("[TODO] Limit pullFormData from pulling the whole sheet - sheetData.getRecentData(maxRows) or something similar? Specify max and min rows?");
 
@@ -103,8 +104,9 @@ function pullFormData(allSheetData) {
         Logger.log("[DEBUG] Skipping marking Form Responses as having been pulled into the data sheet: dataFlow.skipMarkingPulled is set to true");
     }
     else {
+        console.log("During Testing: PUT A BREAKPOINT HERE!")
         let formSheet = fSheetData.getSheet();
-        let markerRange = formSheet.getRange("B2:B" + formSheet.getLastRow());
+        let markerRange = formSheet.getRange(rangeString); // was originally checking the sheet again, and occasionally new responses would slip in here and cause problems
         formSheet.getRange("B2").setValue(true);
         formSheet.getRange("B2").autoFill(markerRange, SpreadsheetApp.AutoFillSeries.DEFAULT_SERIES);
     }

--- a/dataFlow/updateDataSheet.ts
+++ b/dataFlow/updateDataSheet.ts
@@ -71,7 +71,9 @@ function pullFormData(allSheetData) {
     let fSheetData = allSheetData.form;
     let responses = fSheetData.getData();
     let missionData = [];
-    let rangeString = "B2:B" + responses.getLastRow()
+    // Bugfix: the following was previously inside of the last if/else loop.
+    let formSheet = fSheetData.getSheet();
+    let markerRange = formSheet.getRange("B2:B" + formSheet.getLastRow());
 
     Logger.log("[TODO] Limit pullFormData from pulling the whole sheet - sheetData.getRecentData(maxRows) or something similar? Specify max and min rows?");
 
@@ -105,8 +107,7 @@ function pullFormData(allSheetData) {
     }
     else {
         console.log("During Testing: PUT A BREAKPOINT HERE!")
-        let formSheet = fSheetData.getSheet();
-        let markerRange = formSheet.getRange(rangeString); // was originally checking the sheet again, and occasionally new responses would slip in here and cause problems
+        // was originally checking the sheet again, and occasionally new responses would slip in here and cause problems
         formSheet.getRange("B2").setValue(true);
         formSheet.getRange("B2").autoFill(markerRange, SpreadsheetApp.AutoFillSeries.DEFAULT_SERIES);
     }


### PR DESCRIPTION
This is to fix #110- there was a minor logic error where we were re-checking the sheet to get the last row.

Now the last row is grabbed before responses are pulled- so in the event of a new response getting in between two consecutive IO calls, it won't be marked as pulled.  The next time through the data response loop, it'll get marked as pulled and ``markDuplicates`` will be able to solve the occasional double-pull problem.