### PR TITLE
Mark Duplicates Rewrite (#148)

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -8,3 +8,4 @@ docs/**
 .github/**
 deploy-data/**
 deploy_data/**
+deploy-data/required-files/git-info.js

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,2 @@
+git submodule install --update
+npm install

--- a/.github/workflows/BERT-INSTANCE-2.yml
+++ b/.github/workflows/BERT-INSTANCE-2.yml
@@ -3,7 +3,7 @@ name: BERT-INSTANCE-2
 on:
   workflow_dispatch:
   push:
-    branches: [reFactor]
+    branches: [drivehandler-cleaning]
   release:
     types: [published]
   schedule:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,11 +6,7 @@
         "gruntfuggly.todo-tree",
         "bierner.markdown-preview-github-styles",
         "bierner.github-markdown-preview",
-        "eamodio.gitlens",
         "oouo-diogo-perdigao.docthis",
-
-        "christian-kohler.npm-intellisense",
-        "eg2.vscode-npm-script",
-        "HookyQR.beautify"
+        "christian-kohler.npm-intellisense"
     ]
 }

--- a/KIC-config.ts
+++ b/KIC-config.ts
@@ -119,8 +119,8 @@ const INTERNAL_CONFIG = {
         // allSheetData_cacheKey: "puppies and flowers", //ID to use when storing allSheetData in the cache
 
         missionOrgData_cacheEnabled: false, //[unimplemented] Cache missionOrgData, the object returned by getMissionOrgData()
-
-        maxRowToMarkDuplicates: 500, //If set to -1, the full sheet will be checked (which takes a long time!). If set to 0, duplicates will not be marked.
+        // no longer needed post-rewrite
+        // maxRowToMarkDuplicates: 500, //If set to -1, the full sheet will be checked (which takes a long time!). If set to 0, duplicates will not be marked.
 
         log_importContacts: false,
         log_dataMerge: false,
@@ -325,6 +325,7 @@ function getSheetDataConfig(): manySheetDataEntries {
                 tabName: "Form Responses",
                 headerRow: 0,
                 includeSoftcodedColumns: true,
+                use_iterant:true,
                 initialColumnOrder: {
                     areaName: 0,
                     responsePulled: 1,
@@ -394,6 +395,7 @@ function getSheetDataConfig(): manySheetDataEntries {
                 tabName: "Data",
                 headerRow: 0,
                 includeSoftcodedColumns: true,
+                use_iterant:true,
                 keyNamesToIgnore: ["responsePulled", "submissionEmail"],
                 initialColumnOrder: {
                     areaName: 0,

--- a/aa-shortcuts.ts
+++ b/aa-shortcuts.ts
@@ -17,8 +17,13 @@ function run_shareFileSys() {
 }
 
 function run_markDuplicates() {
-    const allSheetData = constructSheetDataV3();
-    markDuplicates(allSheetData);
+    const allSheetData = constructSheetDataV3(["data"]);
+    markDuplicatesV2(allSheetData);
+}
+
+function run_markAllDuplicates() {
+    const allSheetData = constructSheetDataV3(["data"]);
+    markDuplicatesV2(allSheetData,-1)
 }
 
 function run_reportTester() {

--- a/commonLib.ts
+++ b/commonLib.ts
@@ -5,6 +5,7 @@
 const _ = lodash.load();
 
 
+
 function getOrCreateReportFolder() {
     // still used in driveHandlerV3
 
@@ -38,88 +39,88 @@ function getOrCreateReportFolder() {
 // var MERGED_OBJECT = _.merge(OBJ1, OBJ2,OBJ3)
 
 
-function sendDataToDisplayV3_(header, finalData, sheet, args = {sortColumn:1,ascending:true}) {
-    // TODO: *maybe* merge sendDataToDisplay & sendReportToDisplay into one function with a final pre-defined object argument for extra settings, ie start row & column, whether or not to clear out the whole sheet first, etc. 
-    const preDate = new Date
-    // responsible for actually displaying the data.  Clears first to get rid of anything that might be left over.
-    sheet.clearContents();
-    sheet.appendRow(header);
-    console.log(finalData.length);
-    if (CONFIG.commonLib.log_display_info) { console.log("adding Header"); }
-    console.log(header);
-    sheet.getRange(1, 1, 1, header.length).setValues([header]);
-    if (CONFIG.commonLib.log_display_info) { console.log("added header, adding data"); }
-    if (finalData.length == 0 || typeof finalData == null) {
-        console.log("no data, skipping");
-        return;
-    } else {
-        sheet.getRange(2, 1, finalData.length, finalData[0].length).setValues(finalData);
-        if (CONFIG.commonLib.log_display_info) { console.log("Data added, sorting"); }
-        sheet.getRange(2, 1, finalData.length, header.length).sort([{ column: args.sortColumn, ascending: args.ascending }]);
-        // console.log("data added")
-    }
-    const postDate = new Date
-    if (CONFIG.commonLib.log_time_taken) {
-        console.log("Total duration of report display: ", postDate.getTime() - preDate.getTime());
-    }
-}
+// function sendDataToDisplayV3_(header, finalData, sheet, args = {sortColumn:1,ascending:true}) {
+//     // TODO: *maybe* merge sendDataToDisplay & sendReportToDisplay into one function with a final pre-defined object argument for extra settings, ie start row & column, whether or not to clear out the whole sheet first, etc. 
+//     const preDate = new Date
+//     // responsible for actually displaying the data.  Clears first to get rid of anything that might be left over.
+//     sheet.clearContents();
+//     sheet.appendRow(header);
+//     console.log(finalData.length);
+//     if (CONFIG.commonLib.log_display_info) { console.log("adding Header"); }
+//     console.log(header);
+//     sheet.getRange(1, 1, 1, header.length).setValues([header]);
+//     if (CONFIG.commonLib.log_display_info) { console.log("added header, adding data"); }
+//     if (finalData.length == 0 || typeof finalData == null) {
+//         console.log("no data, skipping");
+//         return;
+//     } else {
+//         sheet.getRange(2, 1, finalData.length, finalData[0].length).setValues(finalData);
+//         if (CONFIG.commonLib.log_display_info) { console.log("Data added, sorting"); }
+//         sheet.getRange(2, 1, finalData.length, header.length).sort([{ column: args.sortColumn, ascending: args.ascending }]);
+//         // console.log("data added")
+//     }
+//     const postDate = new Date
+//     if (CONFIG.commonLib.log_time_taken) {
+//         console.log("Total duration of report display: ", postDate.getTime() - preDate.getTime());
+//     }
+// }
 
-function sendReportToDisplayV3_(header, finalData, sheet) {
-    const preDate = new Date
-    // responsible for actually displaying the data.  Clears first to get rid of anything that might be left over.
-    sheet.clearContents();
-    // sheet.appendRow(header);
-    // if (CONFIG.LOG_OLD_sendReportToDisplayV3_) { console.log(finalData.length); }
-    if (CONFIG.commonLib.log_display_info) { console.log("adding Header"); }
-    sheet.getRange(2, 1, 1, header.length).setValues([header]);
-    if (CONFIG.commonLib.log_display_info) {console.log("added header, adding data");}
-        if (finalData == null) {
-            if (CONFIG.commonLib.log_display_info_extended) { console.log("no data, skipping"); }
-        return;
-    }
-    const prepredate = new Date
-    sheet.getRange(3, 1, finalData.length, finalData[0].length).setValues(finalData);
-    if (CONFIG.commonLib.log_display_info) {
-        console.log("data added, sorting");
-    }
-    sheet.getRange(3, 1, finalData.length, header.length).sort([{ column: 1, ascending: true }]);
-    const postDate = new Date
-    if (CONFIG.commonLib.log_time_taken) {
-        console.log("Total duration of report display: ", postDate.getTime() - preDate.getTime());
-    }
-    // going to run this one more time without a flush to see what happens when this changes.
-    // SpreadsheetApp.flush()
-    // console.log("data added")
-}
+// function sendReportToDisplayV3_(header, finalData, sheet) {
+//     const preDate = new Date
+//     // responsible for actually displaying the data.  Clears first to get rid of anything that might be left over.
+//     sheet.clearContents();
+//     // sheet.appendRow(header);
+//     // if (CONFIG.LOG_OLD_sendReportToDisplayV3_) { console.log(finalData.length); }
+//     if (CONFIG.commonLib.log_display_info) { console.log("adding Header"); }
+//     sheet.getRange(2, 1, 1, header.length).setValues([header]);
+//     if (CONFIG.commonLib.log_display_info) {console.log("added header, adding data");}
+//         if (finalData == null) {
+//             if (CONFIG.commonLib.log_display_info_extended) { console.log("no data, skipping"); }
+//         return;
+//     }
+//     const prepredate = new Date
+//     sheet.getRange(3, 1, finalData.length, finalData[0].length).setValues(finalData);
+//     if (CONFIG.commonLib.log_display_info) {
+//         console.log("data added, sorting");
+//     }
+//     sheet.getRange(3, 1, finalData.length, header.length).sort([{ column: 1, ascending: true }]);
+//     const postDate = new Date
+//     if (CONFIG.commonLib.log_time_taken) {
+//         console.log("Total duration of report display: ", postDate.getTime() - preDate.getTime());
+//     }
+//     // going to run this one more time without a flush to see what happens when this changes.
+//     // SpreadsheetApp.flush()
+//     // console.log("data added")
+// }
 
-function getReportOrSetUpFromOtherSource_(sheetName, targetSpreadsheet, headerData = []) {
-    const ss = targetSpreadsheet;
-    let outHeader = [];
+// function getReportOrSetUpFromOtherSource_(sheetName, targetSpreadsheet, headerData = []) {
+//     const ss = targetSpreadsheet;
+//     let outHeader = [];
     
-    let data =[]
-    // Checks to see if the sheet exists or not.
-    let sheet = ss.getSheetByName(sheetName);
-    if (!sheet) {
-        sheet = ss.insertSheet(sheetName);
-        sheet.appendRow(headerData);
-        outHeader = headerData; // Creating Header
-    } else {
-        const outData = sheet.getDataRange().getValues();
-        outHeader = outData[0];
-        if (outData.length > 1) {
-            outHeader = outData.shift()
-            data = outData
-        }
-    }
+//     let data =[]
+//     // Checks to see if the sheet exists or not.
+//     let sheet = ss.getSheetByName(sheetName);
+//     if (!sheet) {
+//         sheet = ss.insertSheet(sheetName);
+//         sheet.appendRow(headerData);
+//         outHeader = headerData; // Creating Header
+//     } else {
+//         const outData = sheet.getDataRange().getValues();
+//         outHeader = outData[0];
+//         if (outData.length > 1) {
+//             outHeader = outData.shift()
+//             data = outData
+//         }
+//     }
 
     
 
-    return {
-        sheet: sheet,
-        headerData: outHeader,
-        data:data
-    };
-}
+//     return {
+//         sheet: sheet,
+//         headerData: outHeader,
+//         data:data
+//     };
+// }
 
 const accessibleFolderCache = {
     good: [],
@@ -211,58 +212,58 @@ function isFileAccessible_(fileID: string):boolean {
     return output;
 }
 
-function splitDataByTagEliminateDupes_(referenceData, tagColumn, dupeColumn) {
-    // TODO No longer referenced.
-    //currently just for zones, but we'll change that once I know this thing actually works.
-    const checkPosition = tagColumn; // for zones
-    const tagList = getUniqueFromPosition_(referenceData, checkPosition);
-    // console.log(tagList)
-    const splitData = {};//[tagList.length]
-    // set up splitData
-    for (const tag of tagList) {
-        splitData[tag] = [];
-    }
-    for (const data of referenceData) {
-        const refTag = data[checkPosition];
-        // console.log(refTag)
-        if (tagList.includes(refTag) == true && (data[dupeColumn] == false || dupeColumn == null /*typeof dupeColumn == "undefined" (ONLY IF THAT DOESN'T WORK)*/)) {
-            const currentTag = tagList[tagList.indexOf(refTag)];
-            // console.log(currentTag)
-            // console.log(tagList.indexOf(refTag))
-            splitData[currentTag].push(data);
-        }
-    }
-    return { data: splitData, tagArray: tagList };
-}
+// function splitDataByTagEliminateDupes_(referenceData, tagColumn, dupeColumn) {
+//     // TODO No longer referenced.
+//     //currently just for zones, but we'll change that once I know this thing actually works.
+//     const checkPosition = tagColumn; // for zones
+//     const tagList = getUniqueFromPosition_(referenceData, checkPosition);
+//     // console.log(tagList)
+//     const splitData = {};//[tagList.length]
+//     // set up splitData
+//     for (const tag of tagList) {
+//         splitData[tag] = [];
+//     }
+//     for (const data of referenceData) {
+//         const refTag = data[checkPosition];
+//         // console.log(refTag)
+//         if (tagList.includes(refTag) == true && (data[dupeColumn] == false || dupeColumn == null /*typeof dupeColumn == "undefined" (ONLY IF THAT DOESN'T WORK)*/)) {
+//             const currentTag = tagList[tagList.indexOf(refTag)];
+//             // console.log(currentTag)
+//             // console.log(tagList.indexOf(refTag))
+//             splitData[currentTag].push(data);
+//         }
+//     }
+//     return { data: splitData, tagArray: tagList };
+// }
 
-function splitDataByTag_(referenceData, tagColumn) {
-    // TODO No longer referenced.
-    //currently just for zones, but we'll change that once I know this thing actually works.
-    const checkPosition = tagColumn; // for zones
-    const tagList = getUniqueFromPosition_(referenceData, checkPosition);
-    // console.log(tagList)
-    const splitData = {};//[tagList.length]
-    // set up splitData
-    for (const tag of tagList) {
-        splitData[tag] = [];
-    }
-    for (const data of referenceData) {
-        const refTag = data[checkPosition];
-        // console.log(refTag)
-        if (tagList.includes(refTag) == true) {
-            const currentTag = tagList[tagList.indexOf(refTag)];
-            splitData[currentTag].push(data);
-        }
-    }
-    return { data: splitData, tagArray: tagList };
-}
-function getUniqueFromPosition_(gimmeDatArray, position) {
-    // this does the same thing as above, but keeps me from needing to iterate through everything twice.
-    const uniqueDataFromPosition = [];
-    for (let i = 0; i < gimmeDatArray.length; i++) {
-        if (uniqueDataFromPosition.includes(gimmeDatArray[i][position]) == false) {
-            uniqueDataFromPosition.push(gimmeDatArray[i][position]); // if it's a match, then we do the thing, otherwise no.
-        }
-    }
-    return uniqueDataFromPosition;
-}
+// function splitDataByTag_(referenceData, tagColumn) {
+//     // TODO No longer referenced.
+//     //currently just for zones, but we'll change that once I know this thing actually works.
+//     const checkPosition = tagColumn; // for zones
+//     const tagList = getUniqueFromPosition_(referenceData, checkPosition);
+//     // console.log(tagList)
+//     const splitData = {};//[tagList.length]
+//     // set up splitData
+//     for (const tag of tagList) {
+//         splitData[tag] = [];
+//     }
+//     for (const data of referenceData) {
+//         const refTag = data[checkPosition];
+//         // console.log(refTag)
+//         if (tagList.includes(refTag) == true) {
+//             const currentTag = tagList[tagList.indexOf(refTag)];
+//             splitData[currentTag].push(data);
+//         }
+//     }
+//     return { data: splitData, tagArray: tagList };
+// // }
+// function getUniqueFromPosition_(gimmeDatArray, position) {
+//     // this does the same thing as above, but keeps me from needing to iterate through everything twice.
+//     const uniqueDataFromPosition = [];
+//     for (let i = 0; i < gimmeDatArray.length; i++) {
+//         if (uniqueDataFromPosition.includes(gimmeDatArray[i][position]) == false) {
+//             uniqueDataFromPosition.push(gimmeDatArray[i][position]); // if it's a match, then we do the thing, otherwise no.
+//         }
+//     }
+//     return uniqueDataFromPosition;
+// }

--- a/dataFlow/markDuplicatesV2.ts
+++ b/dataFlow/markDuplicatesV2.ts
@@ -1,0 +1,366 @@
+// Order of operations:
+/*
+    Load data
+    Add iterant
+    Remove data for time we don't want to check
+    Split data by week and then by area id
+    Check to see if there are multiple entries
+        If there are multiple entries, create corrective entries with the most recent data and the oldest area data
+        Save iterants for things that need to be marked as duplicate
+        Add "CORRECTIVE" to status log for corrected entries
+        Append corrective entries
+    Partial update entries to mark as duplicate for all involved entries
+    Completion.
+
+    Also need to add a timer shunt thing so that we can batch things and not run into time limits
+
+
+
+*/
+
+// import { create } from 'lodash';
+
+//import { entries } from 'lodash';
+
+// Step Uno:  Load Data
+
+interface two_key_grouper {
+    [index:string]:one_key_grouping
+}
+
+interface one_key_grouping {
+    [index:string]:kiDataEntry[]
+}
+
+interface oldestNewest_return_type {
+    oldest: kiDataEntry,
+    newest: kiDataEntry
+}
+function copyObjectNoRecursion_(inObject: object) {
+    const output = {}
+    for (const key in inObject) {
+        output[key] = inObject[key]
+    }
+    return output
+    
+}
+
+
+function testMarkDuplicatesV2() {
+    const allSheetData = constructSheetDataV3(["data"])
+    markDuplicatesV2(allSheetData["data"])
+}
+// WYLO: getOldestAndNewestEntry doesn't seem to be working properly
+
+function getOldestAndNewestEntry(data:kiDataEntry[],timeKey: string): oldestNewest_return_type {
+    const starter = copyObjectNoRecursion_(data[0])
+    const output = {
+        oldest: copyObjectNoRecursion_(starter),
+        newest: copyObjectNoRecursion_(starter)
+    };
+    
+    for (const entry of data) {
+        const current_date = new Date(entry[timeKey])
+        const comparison_date_1 = new Date(output.oldest[timeKey])
+        const comparison_date_2 = new Date(output.newest[timeKey])
+        if (current_date.getTime() > comparison_date_2.getTime()) {
+            output.newest = entry
+        } else if (current_date.getTime() < comparison_date_1.getTime()) {
+            output.newest = entry
+        }
+    }
+
+
+    return output
+}
+
+function createDumbEntry() {
+    function randNum() {
+        return Math.floor(Math.random()*5)
+    }
+    const dumbEntry: kiDataEntry = {
+        areaName: "Mercedes C",
+        // responsePulled: 1,
+        // isDuplicate: 2,
+        formTimestamp: convertToSheetDate_(new Date().toString()),
+        submissionEmail: "DEBUGDATA@LOL",
+        kiDate: convertToSheetDate_(new Date().toString()),
+        np: randNum(),
+        sa: randNum(),
+        bd: randNum(),
+        bc: randNum(),
+        rca: randNum(),
+        rc: randNum(),
+        serviceHrs: randNum(),
+        cki: randNum(),
+        "bap-self-ref": randNum(),
+        "bap-street": randNum(),
+        "bap-ward-activity-or-event": randNum(),
+        "bap-ref-recent-convert": randNum(),
+        "bap-ref-part-member": randNum(),
+        "bap-ref-other-member": randNum(),
+        "bap-ref-teaching-pool": randNum(),
+        "bap-ref-other-non-member": randNum(),
+        "bap-fb-mission": randNum(),
+        "bap-fb-personal": randNum(),
+        "bap-family-history": randNum(),
+        "bap-taught-prev": randNum(),
+        "fb-role": 26,
+        "fb-ref-rgv-eng": randNum(),
+        "fb-ref-rgv-spa": randNum(),
+        "fb-ref-laredo-eng": randNum(),
+        "fb-ref-laredo-spa": randNum(),
+        "fb-ref-ysa": randNum(),
+        "fb-ref-asl": randNum(),
+        "fb-ref-service": randNum(),
+        "fb-ref-corpus": randNum(),
+        "fb-ref-personal": randNum(),
+        "feedback-general": "DEBUG DATA", // had to hardcode these because I added more questions afterwards.
+        "feedback-improvement": "DEBUG DATA",
+        "feedback-analysis": "DEBUG DATA!",
+        "fb-ref-st-eng": randNum(),
+        "fb-ref-st-spa": randNum(),
+        "mpl": randNum(),
+        "RCA-weekly": randNum()
+    };
+
+    const areaNames = ['Mission 3A',"Sharyland B","Mercedes C"]
+    const entries:kiDataEntry[] = []
+    for (let i = 0; i < 5; i++){
+        const entry = { ...dumbEntry }
+        entry["areaName"] = areaNames[i % areaNames.length]
+        entries.push(entry)
+    }
+    // const granulify = new kiDataClass(entries).addGranulatedTime("kiDate", "kiDate", timeGranularities.day).end
+    constructSheetDataV3(["form"]).form.appendData(entries)
+}
+
+function testCreateCorrectedEntry() {
+    const areaData = {
+        area: "WORD",
+        isSister: false,
+        ki1: 123,
+    }
+    const kiData = {
+        area: "WORDLE",
+        isSister: true,
+        ki1: 321
+    }
+    const keysToKeep = ["area", "isSister"]
+    const correctionDate = convertToSheetDate_(new Date())
+    const output = createCorrectedEntry_(areaData,kiData,keysToKeep,correctionDate)
+    const comparison = {
+        area: "WORD",
+        isSister: false,
+        ki1: 321
+    }
+    let pass = true
+    for (const key in areaData) {
+        if (comparison[key] != output[key]) {
+            pass = false
+        }
+    }
+    if (pass) {
+        console.log("✅✔✅ PASS ✅✔✅")
+    } else {
+        console.log("❌⛔❌ FAIL ❌⛔❌")
+    }
+}
+
+function getNewestCorrectedEntry_(data: kiDataEntry[]): kiDataEntry | null{
+    let output = null
+    const logKey = "log"
+    const logTimeKey = "newestTime"
+
+    const correctedEntries: kiDataEntry[] = []
+    for (const entry of data) {
+        if (Object.prototype.hasOwnProperty.call(entry, logKey)) {
+            // check to see if there's any corrected entries
+            if (String(entry[logKey]).includes("CORRECTED_ENTRY")) {
+                // if this is the  first that passes the corrected entry check, set output equal to it
+                if (output == null) {
+                    output = entry
+                } else {
+                    // loads up the status log section of the data, and parses it for the latest timestamp inside.
+                    const outputLogData = JSON.parse(output[logKey])
+                    const testLogData = JSON.parse(entry[logKey])
+                    if (Object.hasOwn(outputLogData, logTimeKey) && Object.hasOwn(testLogData, logTimeKey)) {
+                        // so if we *can* make a comparison, do things... otherwise we just kinda yolo it.
+                        if (outputLogData[logTimeKey] < entry[logTimeKey]) {
+                            output = entry
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+
+    return output
+}
+
+function createCorrectedEntry_(newData: kiDataEntry, areaData: kiDataEntry, keysToKeep: string[],timestamp_key:string) {
+    const output: kiDataEntry = copyObjectNoRecursion_(areaData);
+    for (const key of keysToKeep) {
+        if (Object.hasOwnProperty.call(newData, key)) {
+
+            output[key] = newData[key]
+        }
+    }
+    const logData = {
+        log: "CORRECTED_ENTRY",
+        newestTime:-1
+    }
+    logData.newestTime = new Date(newData[timestamp_key]).getTime()
+    output["log"] = JSON.stringify(logData)
+    output["isDuplicate"] = false
+    return output
+
+}
+
+
+/**
+ * @description
+ * @param {SheetData} dataSheet
+ * @param {number} [weeksToMark=7] Number of weeks: if set to -1 will do all of them.
+ */
+function markDuplicatesV2(dataSheet:SheetData,weeksToMark=7) {
+    const areaDataKeys = [
+        "areaName",
+        "areaEmail",
+        "areaID",
+        "kiDate",
+        "name1",
+        "position1",
+        "isTrainer1",
+        "name2",
+        "position2",
+        "isTrainer2",
+        "name3",
+        "position3",
+        "isTrainer3",
+        "districtLeader",
+        "zoneLeader1",
+        "zoneLeader2",
+        "zoneLeader3",
+        "stl1",
+        "stl2",
+        "stl3",
+        "stlt1",
+        "stlt2",
+        "stlt3",
+        "assistant1",
+        "assistant2",
+        "assistant3",
+        "district",
+        "zone",
+        "unitString",
+        "hasMultipleUnits",
+        "languageString",
+        "isSeniorCouple",
+        "isSisterArea",
+        "hasVehicle",
+        "vehicleMiles",
+        "vinLast8",
+        "aptAddress",
+        "fb-role"
+    ]
+    const dataClass = new kiDataClass(dataSheet.getData())
+    // const iterantKey = "add_iterant"
+    // dataClass.addIterant(iterantKey,1)
+    const time_key = "kiDate"
+    const timestamp_key = "formTimestamp"
+    const area_id_key = "areaID"
+
+    const cutoffDate = new Date();
+    const day = cutoffDate.getTime() - ( ((weeksToMark * 7) + 1) * 24 * 60 * 60 * 1000);
+    cutoffDate.setTime(day)
+    // disabled ATM because test data is old
+    if (weeksToMark != -1) {
+        dataClass.removeBeforeDate(cutoffDate)
+    }
+    if (weeksToMark == 0) {
+        console.error("Marking zero day's worth of duplicates.")
+    }
+    
+    //@ts-expect-error I'm intentionally abusing this.  Llore.
+    const aggData: two_key_grouper = dataClass.groupDataByMultipleKeys([time_key, area_id_key])
+    
+    const correctionEntries: kiDataEntry[] = []
+    const markAsDuplicateEntries : kiDataEntry[] = []
+    const okEntries: kiDataEntry[] = []
+    const itkey = dataSheet.iterantKey
+    // outer loop
+    for(const date in aggData) {
+        const dataForWeek = aggData[date]
+        for (const areaID in dataForWeek) {
+            const data = dataForWeek[areaID]
+            // if there's nothing, skiiiip
+            if (data.length > 1) {
+                // check to see if data has corrected entries in it.
+                // If so, check and see if the most recent * not * corrected entry is the same as it was.
+
+                const newestCorrectedEntry = getNewestCorrectedEntry_(data)
+
+                for (const entry of data) {
+                    
+                    const dupeMarker: kiDataEntry = {
+                        isDuplicate:true
+                    }
+                    // row assignment.  Because it's possible to change the name we
+                    // can't hardcode the iterant key value and therefore have to
+                    // resort to not making this be part of the variable declaration.
+
+                    dupeMarker[itkey] = entry[itkey]
+                    
+                    // was having problems with the previous corrected entries getting marked as duplicate.
+                    // I think this fixes that.
+                    // let markAsDuplicate = true
+                    if (newestCorrectedEntry == null || newestCorrectedEntry[itkey] != entry[itkey]) {
+                        markAsDuplicateEntries.push(dupeMarker)
+                    }
+                    
+                }
+                const relevantEntries = getOldestAndNewestEntry(data, timestamp_key)
+                // check to see if the newest corrected entry already has that information or not
+                const correctedEntry = createCorrectedEntry_(relevantEntries.newest, relevantEntries.oldest, areaDataKeys, timestamp_key)
+
+                const correctionDupeMarker: kiDataEntry = {
+                    isDuplicate:true
+                }
+                // adds iterant key from newest corrective entry in case it needs to be marked as duplicate
+                if (newestCorrectedEntry != null) {
+                    correctionDupeMarker[itkey] = newestCorrectedEntry[itkey];
+                }
+
+                if (newestCorrectedEntry == null) {
+                    correctionEntries.push(correctedEntry)
+                    // markAsDuplicateEntries.push(correctionDupeMarker)
+                } else if (relevantEntries.newest[timestamp_key] > newestCorrectedEntry[timestamp_key]){
+                    correctionEntries.push(correctedEntry)
+                    markAsDuplicateEntries.push(correctionDupeMarker)
+                    
+                } else {
+                    // console.log("Skipped adding correction because it was up to date")
+                    okEntries.push(correctionDupeMarker)
+                }
+
+            } else {
+                for (const entry of data) {
+                    okEntries.push(entry)
+                }
+            }
+        }
+    }
+    // WYLO 2023-03-01: okentries needs to get updated to use the new kiDataEntry format stuff as well.
+    // mark duplicates- I need to figure out a better / more efficient way of doing this...
+    dataSheet.appendData(correctionEntries)
+    dataSheet.updateRows(markAsDuplicateEntries)
+    console.log("Skipped adding ",String(okEntries.length),"entries that were already up to date!")
+    // for (const duplicate of markAsDuplicateEntries) {
+    //     dataSheet.directModify(duplicate, { "isDuplicate": true })
+    // }
+    // for (const notDuplicate of okEntries) {
+    //     dataSheet.directModify(notDuplicate, { "isDuplicate": false })
+    // }
+}

--- a/dataFlow/updateDataSheet.ts
+++ b/dataFlow/updateDataSheet.ts
@@ -21,17 +21,23 @@ function updateDataSheet() {
     console.log("BEGINNING UPDATE");
 
 
-
-    const allSheetData: manySheetDatas = constructSheetDataV3(["contact", "form"]);
+    // build the sheet data- we need contact data for mission org information
+    const allSheetData: manySheetDatas = constructSheetDataV3(["contact", "form","data"]);
     
     const cDataSheet: SheetData = allSheetData.contact;
     const fDataSheet: SheetData = allSheetData.form;
-    
+
+
+    // sync dataflow columns, to allow new questions to automatically get pushed through to the data
+    console.log("Syncing Columns From Form Responses To Data")
+    allSheetData.data.addKeys(fDataSheet)
+
+    // patching to use better marking method
+    const iterantKey = fDataSheet.iterantKey
 
     if (CONFIG.dataFlow.forceAreaIdReloadOnUpdateDataSheet) {
         loadAreaIDs(cDataSheet);
     } //Force a full recalculation
-
 
     //checkForErrors()?  Ex. no contact data
     
@@ -42,7 +48,7 @@ function updateDataSheet() {
         return;
     }
 
-    const numberOfEntries = missionData.length
+    // const numberOfEntries = missionData.length
     // former ignore
     // makeSheet();
     refreshContacts(allSheetData);
@@ -55,23 +61,35 @@ function updateDataSheet() {
     missionData = mergeIntoMissionData(missionData, leaders, "leadership data");
 
     // FIRST, ADD THE DATA TO THE SHEETS
-    allSheetData.data.insertData(missionData);
+    allSheetData.data.appendData(missionData);
+    
     // THEN MARK THE STUFF AS HAVING BEEN PULLED
+
+    // make the partial modify set
+    const markPulledSet:kiDataEntry[] = []
+    for (const entry of missionData) {
+        const markerData: kiDataEntry = { responsePulled: true }
+        // this associates every row entry from the data with the partial modify subset
+        markerData[iterantKey] = entry[iterantKey]
+        markPulledSet.push(markerData)
+    }
 
     if (CONFIG.dataFlow.skipMarkingPulled) {
         console.warn("[DEBUG] Skipping marking responses as pulled");
     } else {
-
-        const column = allSheetData.form.getIndex("responsePulled")
-        const minRow = allSheetData.form.rsd.headerRow + 1
-        allSheetData.form.rsd.sheet.getRange(minRow, column,numberOfEntries,1)
+        // then push that set to the form response sheet
+        allSheetData.form.updateRows(markPulledSet)
+        // compared to the old version, this is a *lot* easier to read.
+        // const column = allSheetData.form.getIndex("responsePulled")
+        // const minRow = allSheetData.form.rsd.headerRow + 1
+        // allSheetData.form.rsd.sheet.getRange(minRow, column,numberOfEntries,1)
     }
 
-    if (CONFIG.dataflow.skipMarkingPulled) {
+    if (CONFIG.dataFlow.skipMarkingPulled) {
         Logger.log("[DEBUG] Skipping marking Form Responses as having been pulled into the data sheet: dataFlow.skipMarkingPulled is set to true");
         return        
     } else {
-        markDuplicates(allSheetData);
+        markDuplicatesV2(allSheetData.data);
     }
 
     pushErrorMessages();  //Unimplemented

--- a/docs/Presentation#2Notes.md
+++ b/docs/Presentation#2Notes.md
@@ -1,0 +1,22 @@
+# MLC Presentation #2
+
+## Changes since last year
+
+huge increase in stability & reliability
+
+finding font for last year
+
+reports have come a *long* way
+
+- update times down from an hour to an average of (Numbers here) with a variation of (more numbers)
+
+
+
+Training Bit
+
+- Reporting - *please* check!
+- How to use the charts? Training / Demo
+
+Questions we have:
+    - things resolved at last MLC: people can only see data for their stewardship
+    - 

--- a/fileSys/driveHandlerV4.ts
+++ b/fileSys/driveHandlerV4.ts
@@ -261,7 +261,6 @@ function loadFilesystems_(allSheetData: manySheetDatas): manyFilesystemEntries {
 }
 
 function verifyFSV4(allSheetData = constructSheetDataV3()) {
-function verifyFSV4(allSheetData = constructSheetDataV3()) {
     const filesystems = loadFilesystems_(allSheetData);
 
     for (const filesystem in filesystems) {

--- a/fileSys/driveHandlerV4.ts
+++ b/fileSys/driveHandlerV4.ts
@@ -229,24 +229,21 @@ function loadFilesystems_(allSheetData: manySheetDatas): manyFilesystemEntries {
     const filesystems: manyFilesystemEntries = {
 
         Zone: {
-            fsData: allSheetData.zone,
-            fsData: allSheetData.zone,
+            fsData: allSheetData.zoneFilesys,
             fsScope: CONFIG.fileSystem.reportLevel.zone,
             sheetData: [],
             existingFolders: [],
             reportTemplate: CONFIG.reportCreator.docIDs.zoneTemplate
         },
         District: {
-            fsData: allSheetData.district,
-            fsData: allSheetData.district,
+            fsData: allSheetData.distFilesys,
             fsScope: CONFIG.fileSystem.reportLevel.dist,
             sheetData: [],
             existingFolders: [],
             reportTemplate: CONFIG.reportCreator.docIDs.distTemplate
         },
         Area: {
-            fsData: allSheetData.area,
-            fsData: allSheetData.area,
+            fsData: allSheetData.areaFilesys,
             fsScope: CONFIG.fileSystem.reportLevel.area,
             sheetData: [],
             existingFolders: [],

--- a/fileSys/driveHandlerV4.ts
+++ b/fileSys/driveHandlerV4.ts
@@ -54,12 +54,10 @@ class fsEntry {
 
 function updateFSV4() {
     const allSheetData: manySheetDatas = constructSheetDataV3();
-
-    verifyFSV4(allSheetData);
-    clearAllSheetDataCache();
-    buildFSV4();
-    updateShards();
-    
+    verifyFSV4(allSheetData)
+    clearAllSheetDataCache()
+    buildFSV4()
+    updateShards()
 }
 
 interface closedData {
@@ -232,6 +230,7 @@ function loadFilesystems_(allSheetData: manySheetDatas): manyFilesystemEntries {
 
         Zone: {
             fsData: allSheetData.zone,
+            fsData: allSheetData.zone,
             fsScope: CONFIG.fileSystem.reportLevel.zone,
             sheetData: [],
             existingFolders: [],
@@ -239,12 +238,14 @@ function loadFilesystems_(allSheetData: manySheetDatas): manyFilesystemEntries {
         },
         District: {
             fsData: allSheetData.district,
+            fsData: allSheetData.district,
             fsScope: CONFIG.fileSystem.reportLevel.dist,
             sheetData: [],
             existingFolders: [],
             reportTemplate: CONFIG.reportCreator.docIDs.distTemplate
         },
         Area: {
+            fsData: allSheetData.area,
             fsData: allSheetData.area,
             fsScope: CONFIG.fileSystem.reportLevel.area,
             sheetData: [],
@@ -262,6 +263,7 @@ function loadFilesystems_(allSheetData: manySheetDatas): manyFilesystemEntries {
     return filesystems;
 }
 
+function verifyFSV4(allSheetData = constructSheetDataV3()) {
 function verifyFSV4(allSheetData = constructSheetDataV3()) {
     const filesystems = loadFilesystems_(allSheetData);
 

--- a/reports/reportUpdater V5.ts
+++ b/reports/reportUpdater V5.ts
@@ -240,7 +240,6 @@ function convertToFilesystemData(kiData:kiDataEntry[]):filesystemData[] {
 function testDoDataOperationsLive() {
     // integration-style test
     const localSheetData: manySheetDatas = constructSheetDataV3(["distFilesys", "data"]);
-    const localSheetData: manySheetDatas = constructSheetDataV3(["distFilesys", "data"]);
     const fsData: filesystemData[] = convertToFilesystemData(localSheetData.distFilesys.getData())
     // let targetFSData: manyFilesystemDatas = { entry1: fsData[1], entry2: fsData[2] }
     let kiData = new kiDataClass(localSheetData.data.getData());
@@ -292,7 +291,6 @@ function testKeepMatchingByKey() {
 function testKeepMatchingByKey2() {
     // semi-integrated test- loads external data
     const localSheetData: manySheetDatas = constructSheetDataV3(["data"]);
-    const localSheetData: manySheetDatas = constructSheetDataV3(["data"]);
 
     const testKey = "areaID";
     const kiData = localSheetData.data.getData();
@@ -302,8 +300,6 @@ function testKeepMatchingByKey2() {
 }
 
 function testGroupAndSendReports(): void {
-    // integration test: loads external data, pushes it
-    const localSheetData: manySheetDatas = constructSheetDataV3(["distFilesys","data"]);
     // integration test: loads external data, pushes it
     const localSheetData: manySheetDatas = constructSheetDataV3(["distFilesys","data"]);
     const fsData:filesystemData[] = convertToFilesystemData(localSheetData.distFilesys.getData())
@@ -366,7 +362,6 @@ function groupDataAndSendReports_(fsData: filesystemData[], kiData: kiDataClass,
  */
 function testSingleReportUpdater():void {
     
-    const localSheetData: manySheetDatas = constructSheetDataV3(["data"]);
     const localSheetData: manySheetDatas = constructSheetDataV3(["data"]);
 
     const kiData = new kiDataClass(localSheetData.data.getData()).calculateCombinedName().createSumOfKeys(CONFIG.kiData.fb_referral_keys,CONFIG.kiData.new_key_names.fb_referral_sum).keepMatchingByKey("district",["ZAPATA","Zapata"]).end

--- a/reports/reportUpdater V5.ts
+++ b/reports/reportUpdater V5.ts
@@ -240,6 +240,7 @@ function convertToFilesystemData(kiData:kiDataEntry[]):filesystemData[] {
 function testDoDataOperationsLive() {
     // integration-style test
     const localSheetData: manySheetDatas = constructSheetDataV3(["distFilesys", "data"]);
+    const localSheetData: manySheetDatas = constructSheetDataV3(["distFilesys", "data"]);
     const fsData: filesystemData[] = convertToFilesystemData(localSheetData.distFilesys.getData())
     // let targetFSData: manyFilesystemDatas = { entry1: fsData[1], entry2: fsData[2] }
     let kiData = new kiDataClass(localSheetData.data.getData());
@@ -291,6 +292,7 @@ function testKeepMatchingByKey() {
 function testKeepMatchingByKey2() {
     // semi-integrated test- loads external data
     const localSheetData: manySheetDatas = constructSheetDataV3(["data"]);
+    const localSheetData: manySheetDatas = constructSheetDataV3(["data"]);
 
     const testKey = "areaID";
     const kiData = localSheetData.data.getData();
@@ -300,6 +302,8 @@ function testKeepMatchingByKey2() {
 }
 
 function testGroupAndSendReports(): void {
+    // integration test: loads external data, pushes it
+    const localSheetData: manySheetDatas = constructSheetDataV3(["distFilesys","data"]);
     // integration test: loads external data, pushes it
     const localSheetData: manySheetDatas = constructSheetDataV3(["distFilesys","data"]);
     const fsData:filesystemData[] = convertToFilesystemData(localSheetData.distFilesys.getData())
@@ -362,6 +366,7 @@ function groupDataAndSendReports_(fsData: filesystemData[], kiData: kiDataClass,
  */
 function testSingleReportUpdater():void {
     
+    const localSheetData: manySheetDatas = constructSheetDataV3(["data"]);
     const localSheetData: manySheetDatas = constructSheetDataV3(["data"]);
 
     const kiData = new kiDataClass(localSheetData.data.getData()).calculateCombinedName().createSumOfKeys(CONFIG.kiData.fb_referral_keys,CONFIG.kiData.new_key_names.fb_referral_sum).keepMatchingByKey("district",["ZAPATA","Zapata"]).end


### PR DESCRIPTION
Duplicate marking has now been drastically improved.

To make this capable of handling entries going at the bottom, markDuplicatesV2 now filters out old entries by giving it a maximum number of weeks instead of number of rows.

Corrected entries are now created that keep the area data from the first submission, thereby making sure that those people get credit for their work instead of overwriting them. (This mostly happens near transfers.)